### PR TITLE
Improve html-webpack-plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ If you don't want the CSS included in your JS but emit it as external files, you
 
 ### html-webpack-plugin
 
-If you're using the hash feature of webpack (e.g. `[name].[hash].js`) chances are high you're also using the [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) to inject the hashed files into your templates. Good news – the media query plugin supports it! It hooks into the plugin and makes sure the extracted files are available in your HTML template via `htmlWebpackPlugin.files.js` or `htmlWebpackPlugin.files.css`.
+If you're using the hash feature of webpack (e.g. `[name].[hash].js`) you might also be using the [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) to inject the hashed files into your templates. Good news – the media query plugin supports it! It hooks into the plugin and makes extracted files available in your HTML template via `htmlWebpackPlugin.files.extracted.js` or `htmlWebpackPlugin.files.extracted.css`.
+
+This let you inject something as `<link rel="stylesheet" href="..." media="...">` so that the extracted files get downloaded but not applied if not necessary (reduces render blocking time). However most of the time it's better to use dynamic imports for the extracted CSS to achieve best performance.
+
+Compared to the regular files (`htmlWebpackPlugin.files.js` or `htmlWebpackPlugin.files.css`) the extracted files object does not have the structure `[file, file]` but `[{file:file,query:query}, {file:file,query:query}]`. Keep this in mind when using it (or check out the example [template](examples/webpack/src/index.hbs)).
 
 ## Not using webpack?
 

--- a/examples/webpack/src/index.hbs
+++ b/examples/webpack/src/index.hbs
@@ -6,12 +6,18 @@
 {{# each htmlWebpackPlugin.files.css }}
     <link rel="stylesheet" href="{{ this }}">
 {{/ each }}
+{{# each htmlWebpackPlugin.files.extracted.css }}
+    <link rel="stylesheet" href="{{ this.file }}" media="{{ this.query }}">
+{{/ each }}
 </head>
 <body>
     <h1 class="foo bar">Hello World</h1>
     <p class="lorem">Lorem ipsum</p>
 {{# each htmlWebpackPlugin.files.js }}
     <script src="{{ this }}"></script>
-{{/each}}
+{{/ each}}
+{{# each htmlWebpackPlugin.files.extracted.js }}
+    <script src="{{ this.file }}"></script>
+{{/ each}}
 </body>
 </html>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -65,6 +65,7 @@ module.exports = class MediaQueryPlugin {
                 store.getMediaKeys().forEach(mediaKey => {
 
                     const css = store.getMedia(mediaKey);
+                    const queries = store.getQueries(mediaKey);
 
                     // generate hash and use for [hash] within basename
                     const hash = interpolateName({}, `[hash:${compiler.options.output.hashDigestLength}]`, { content: css });
@@ -85,6 +86,12 @@ module.exports = class MediaQueryPlugin {
                     }
 
                     const chunk = chunks.filter(chunk => chunk.id === mediaKey)[0];
+
+                    // add query to chunk data if available
+                    // can be used to determine query of a chunk (html-webpack-plugin)
+                    if (queries) {
+                        chunk.query = queries[0];
+                    }
 
                     // find existing js & css files of this chunk
                     let existingFiles = { js: [], css: [] };
@@ -159,19 +166,37 @@ module.exports = class MediaQueryPlugin {
                 cb();
             });
 
-            // consider html-webpack-plugin and provide generated assets to it
-            // so the new assets appear in html template 
-            compilation.hooks.optimizeAssets.tapAsync(pluginName, (assets, cb) => {
+            // consider html-webpack-plugin and provide extracted files
+            // which can be accessed in templates via htmlWebpackPlugin.files.extracted
+            // { css: [{file:'',query:''},{file:'',query:''}] }
+            compilation.hooks.afterOptimizeChunkAssets.tap(pluginName, (chunks) => {
                 if (compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration) {
                     compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapAsync(pluginName, (pluginArgs, cb) => {
-                        const assetKeys = Object.keys(assets);
-                        pluginArgs.assets.js = assetKeys.filter(key => key.match(/\.js$/));
-                        pluginArgs.assets.css = assetKeys.filter(key => key.match(/\.css$/));
-                        pluginArgs.plugin.assetJson = assetKeys;
+                        const assetJson = [];
+                        const extracted = {};
+
+                        chunks.forEach(chunk => {
+                            const query = chunk.query;
+                            
+                            chunk.files.forEach(file => {
+                                const ext = file.match(/\w+$/)[0];
+                                
+                                if (query) {
+                                    extracted[ext] = extracted[ext] || [];
+                                    extracted[ext].push({
+                                        file: file,
+                                        query: query
+                                    });
+                                }
+                                assetJson.push(file);
+                            });
+                        });
+
+                        pluginArgs.assets.extracted = extracted;
+                        pluginArgs.plugin.assetJson = JSON.stringify(assetJson);
                         cb();
                     });
                 }
-                cb();
             });
 
         });

--- a/src/postcss.js
+++ b/src/postcss.js
@@ -11,8 +11,9 @@ module.exports = postcss.plugin('MediaQueryPostCSS', options => {
     function addToStore(name, atRule) {
 
         const css = postcss.root().append(atRule).toString();
+        const query = atRule.params;
         
-        store.addMedia(name, css, options.path);
+        store.addMedia(name, css, options.path, query);
     }
 
     function getGroupName(name) {

--- a/src/store.js
+++ b/src/store.js
@@ -10,11 +10,12 @@ class MediaQueryStore {
         this.options = {};
     }
 
-    addMedia(key, css, filename) {
+    addMedia(key, css, filename, query) {
         const data = {
             css: css,
-            filename: filename
-        }
+            filename: filename,
+            query: query
+        };
 
         if (typeof this.media[key] !== 'object') {
             this.media[key] = [];
@@ -24,10 +25,18 @@ class MediaQueryStore {
 
     getMedia(key) {
         // create css array from media[key] data
-        // which has the structure [{css:'',filename:''},{css:'',filename:''}]
+        // which has the structure [{css:'',filename:'',query:''},{css:'',filename:'',query:''}]
         const css = this.media[key].map(data => data.css);
 
         return css.join('\n');
+    }
+
+    getQueries(key) {
+        // create queries array from media[key] data
+        // which can be used to determine the used query for a key
+        const queries = this.media[key].map(data => data.query);
+
+        return queries;
     }
 
     removeMediaByFilename(filename) {


### PR DESCRIPTION
Fixes #5

This PR enable a more meaningful usage of the html-webpack-plugin instead of just injecting the extracted CSS files (what is quite useless).

Now it can be used to auto set the appropriate `media` value of the `<link>` tag so that it can be used to prevent applying the CSS code to the browser CSS object.

(the file gets still downloaded of course)