### PR TITLE
fix injection when using style-loader

### DIFF
--- a/examples/webpack/src/example.js
+++ b/examples/webpack/src/example.js
@@ -2,6 +2,6 @@
 import './example.scss';
 import './example2.scss';
 
-if (window.innerWidth >= 960) {
+if (window.innerWidth <= 960) {
     import(/* webpackChunkName: 'example-desktop' */ './example-desktop.scss');
 }


### PR DESCRIPTION
Fixes #6 

Instead of prepending the extracted CSS when using the style-loader, I'm now breaking up the source code and inject it right after `// module`.