### PR TITLE
fix: add more tolerance for query match

### DIFF
--- a/src/postcss.js
+++ b/src/postcss.js
@@ -5,6 +5,7 @@
 
 const postcss = require('postcss');
 const store = require('./store');
+const normalize = require('./utils/normalize');
 
 module.exports = postcss.plugin('MediaQueryPostCSS', options => {
 
@@ -35,11 +36,21 @@ module.exports = postcss.plugin('MediaQueryPostCSS', options => {
         }
     }
 
+    function getQueryName(query) {
+        const queries = Object.keys(options.queries);
+
+        for (let i = 0; i < queries.length; i++) {
+            if (normalize(query) === normalize(queries[i])) {
+                return options.queries[queries[i]];
+            }
+        }
+    }
+
     return (css, result) => {
 
         css.walkAtRules('media', atRule => {
 
-            const queryname = options.queries[atRule.params];
+            const queryname = getQueryName(atRule.params);
 
             if (queryname) {
                 const groupName = getGroupName(options.basename);

--- a/src/utils/normalize.js
+++ b/src/utils/normalize.js
@@ -1,0 +1,6 @@
+// Utility to normalize a query for more tolerant comparison.
+// normalize('@media (min-width: 1000px)') === normalize('@media(min-width:1000px)')
+
+module.exports = function normalize(query) {
+  return query.toLowerCase().replace(/\s/g, '');
+}


### PR DESCRIPTION
This makes the query comparison more tolerant so that `'@media (min-width:1000px)'` is considered identical to `'@media (min-width: 1000px)'`

Closes #46 