### PR TITLE
Feature: Control output filename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ if (window.innerWidth >= 960) {
 
 The following options are available.
 
-| name        | mandatory |
-| ----------- | --------- |
-| include     | yes       |
-| queries     | yes       |
-| groups      | no        |
+| name           | mandatory |
+| -------------- | --------- |
+| include        | yes       |
+| queries        | yes       |
+| groups         | no        |
+| outputFileName | no        |
 
 ### include
 
@@ -167,6 +168,31 @@ groups: {
 groups: {
     app: /^example/
 }
+```
+
+### outputFileName
+
+If emitted, the plugin will automatically generate the filename for each CSS that is extracted. If defined, as a `Function`, you gain control of the output filename for each extracted CSS, where the `Function` returns the name for the given file as a `String`.
+
+The function receives one parameter in the form of an `Object`, containing both the options you provide to the plugin, and the following properties:
+
+| name       | type    |
+| ---------- | ------- |
+| groups     | Object  |
+| filename   | String  |
+| basename   | String  |
+| path       | String  |
+| queryname  | String  |
+| groupname  | String  |
+
+The option can be used like this:
+```javascript
+outputFileName: ({ path, queryname }) => {
+    // Path: /Users/[user]/project/component-name/index.vue
+    // Queryname: desktop
+    const pathParts = path.split('/');
+    return `${pathParts[pathParts.length - 2]}-${queryname}`;
+},
 ```
 
 ## Other Webpack Plugins

--- a/src/postcss.js
+++ b/src/postcss.js
@@ -54,7 +54,10 @@ module.exports = postcss.plugin('MediaQueryPostCSS', options => {
 
             if (queryname) {
                 const groupname = getGroupName(options.basename);
-                const name = groupname ? `${groupname}-${queryname}` : `${options.basename}-${queryname}`;
+                const name = options.outputFileName instanceof Function
+                    ? options.outputFileName({ ...options, queryname, groupname })
+                    : groupname ? `${groupname}-${queryname}` : `${options.basename}-${queryname}`;
+
                 addToStore(name, atRule);
                 atRule.remove();
             }

--- a/src/postcss.js
+++ b/src/postcss.js
@@ -53,9 +53,8 @@ module.exports = postcss.plugin('MediaQueryPostCSS', options => {
             const queryname = getQueryName(atRule.params);
 
             if (queryname) {
-                const groupName = getGroupName(options.basename);
-                const name = groupName ? `${groupName}-${queryname}` : `${options.basename}-${queryname}`;
-                
+                const groupname = getGroupName(options.basename);
+                const name = groupname ? `${groupname}-${queryname}` : `${options.basename}-${queryname}`;
                 addToStore(name, atRule);
                 atRule.remove();
             }


### PR DESCRIPTION
I started using this plugin in my current project at work and found two major things we needed for this to work properly in our setup. We are using a Vue setup with Webpack that builds everything together, nothing too fancy. The issue was that the files were all named `index.vue`, simply for ease of use in import/require instances. And instead, the components would have a unique folder, named after the component, that would then contain a `index.vue` file.

This caused an issue where we didn't have the option to either define components to be included, because all components were named `index` according to the plugin. And if we included all the components, using the `include: true;` option, they would all overwrite each other as `index-[queryname].css` files.

This PR adds an option to control the output filename for each extracted CSS, allowing us in this case to use the file path to determine the correct filename.

This is of course not necessary to add to your plugin, as we can use my fork of it. But I figured it could be useful for other people. 🙂