### PR TITLE
Feature: Add option for path includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ if (window.innerWidth >= 960) {
 
 The following options are available.
 
-| name        | mandatory |
-| ----------- | --------- |
-| include     | yes       |
-| queries     | yes       |
-| groups      | no        |
+| name         | mandatory |
+| ------------ | --------- |
+| include      | yes       |
+| queries      | yes       |
+| groups       | no        |
+| pathIncludes | no        |
 
 ### include
 
@@ -167,6 +168,17 @@ groups: {
 groups: {
     app: /^example/
 }
+```
+
+### pathIncludes
+
+This option let's you define what the path of the file in question needs to contain in order to be included in the process. The option is defined as an `Array` and the contents are of the type `String`. So an example could be:
+```javascript
+pathIncludes: ['header-site', 'footer-site']
+
+// Path: /Users/[user]/project/header-site/index.css -> true
+// Path: /Users/[user]/project/post-list/index.css -> false
+// Path: /Users/[user]/project/subComponents/footer-site/index.css -> true
 ```
 
 ## Other Webpack Plugins

--- a/src/loader.js
+++ b/src/loader.js
@@ -31,6 +31,8 @@ module.exports = function(source) {
         isIncluded = true;
     } else if (options.include instanceof RegExp && options.basename.match(options.include)) {
         isIncluded = true;
+    } else if (options.pathIncludes instanceof Array && options.pathIncludes.find(inc => options.path.indexOf(inc) > -1)) {
+        isIncluded = true;
     } else if (options.include === true) {
         isIncluded = true;
     }


### PR DESCRIPTION
I started using this plugin in my current project at work and found two major things we needed for this to work properly in our setup. We are using a Vue setup with Webpack that builds everything together, nothing too fancy. The issue was that the files were all named index.vue, simply for ease of use in import/require instances. And instead, the components would have a unique folder, named after the component, that would then contain a index.vue file.

This caused an issue where we didn't have the option to either define components to be included, because all components were named index according to the plugin. And if we included all the components, using the include: true; option, they would all overwrite each other as index-[queryname].css files.

This PR adds an option to specify what a file path must contain in order to be included.

This is of course not necessary to add to your plugin, as we can use my fork of it. But I figured it could be useful for other people. 🙂