### PR TITLE
Enhence the compatilbily of filename as Function, also using Entrypoint names as includes and groups

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,6 +1,6 @@
 /**
  * The loader component is supposed to extract the media CSS from the source chunks.
- * To do this it uses a custom PostCSS plugin. 
+ * To do this it uses a custom PostCSS plugin.
  * In the course of this the original media CSS gets removed.
  */
 
@@ -9,7 +9,7 @@ const postcss = require('postcss');
 const store = require('./store');
 const plugin = require('./postcss');
 
-module.exports = function(source) {
+module.exports = function (source) {
 
     // make loader async
     const cb = this.async();
@@ -24,20 +24,57 @@ module.exports = function(source) {
     // (don't use options.filename to avoid name conflicts)
     options.path = interpolateName(this, '[path][name].[ext]', {});
 
+
+    // get responding EntryPoint name
+    // for those using <Object> Entries
+    let webpackEntryPoint = '';
+    this._compilation.entries.forEach(entry => {
+        entry.dependencies.forEach(file => {
+
+            const FileEntry = file.request;
+            let FileEntry_Resolved = '';
+
+            if (FileEntry.startsWith("/") ||
+                (FileEntry.length > 1 && FileEntry[1] === ":")
+            ) {
+                FileEntry_Resolved = FileEntry;
+            } else {
+                FileEntry_Resolved = this.rootContext + FileEntry.replace(/^.\//, '/');
+            }
+
+            if ('' == webpackEntryPoint && FileEntry_Resolved === options.path) {
+                webpackEntryPoint = entry.options.name;
+            }
+        });
+    });
+    options.entrypoint = webpackEntryPoint;
+
+
     let isIncluded = false;
 
     // check if current file should be affected
-    if (options.include instanceof Array && options.include.indexOf(options.basename) !== -1) {
+    if (options.include === true) {
         isIncluded = true;
-    } else if (options.include instanceof RegExp && options.basename.match(options.include)) {
-        isIncluded = true;
-    } else if (options.include === true) {
-        isIncluded = true;
+    } else {
+        if (1 == Object.keys(this._compilation.entries).length) {
+            if (options.include instanceof Array && options.include.indexOf(options.basename) !== -1) {
+                isIncluded = true;
+            } else if (options.include instanceof RegExp && options.basename.match(options.include)) {
+                isIncluded = true;
+            }
+        }
+        else {
+            if (options.include instanceof Array && options.include.indexOf(options.entrypoint) !== -1) {
+                isIncluded = true;
+            } else if (options.include instanceof RegExp && options.entrypoint.match(options.include)) {
+                isIncluded = true;
+            }
+        }
     }
 
     // return (either modified or not) source
     if (isIncluded === true) {
-        postcss([ plugin(options) ])
+        postcss([plugin(options)])
             .process(source, { from: options.basename })
             .then(result => {
                 cb(null, result.toString())

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -67,22 +67,22 @@ module.exports = class MediaQueryPlugin {
 
                 const chunks = compilation.chunks;
                 const chunkIds = [...chunks].map(chunk => chunk.id);
-                const assets =  hasDeprecatedChunks ? compilation.assets : compilationAssets;
+                const assets = hasDeprecatedChunks ? compilation.assets : compilationAssets;
 
                 store.getMediaKeys().forEach(mediaKey => {
 
                     const css = store.getMedia(mediaKey);
                     const queries = store.getQueries(mediaKey);
 
-                    // generate hash and use for [hash] within basename
-                    const hash = interpolateName({}, `[hash:${compiler.options.output.hashDigestLength}]`, { content: css });
+                    // // generate hash and use for [hash] within basename
+                    // const hash = interpolateName({}, `[hash:${compiler.options.output.hashDigestLength}]`, { content: css });
 
-                    // compute basename according to filename option
-                    // while considering hash
-                    const basename = this.options.filename
-                                        .replace('[name]', mediaKey)
-                                        .replace(/\[(content|chunk)?hash\]/, hash)
-                                        .replace(/\.[^.]+$/, '');
+                    // // compute basename according to filename option
+                    // // while considering hash
+                    // const basename = this.options.filename
+                    //                     .replace('[name]', mediaKey)
+                    //                     .replace(/\[(content|chunk)?hash\]/, hash)
+                    //                     .replace(/\.[^.]+$/, '');
 
                     // if there's no chunk for the extracted media, create one
                     if (chunkIds.indexOf(mediaKey) === -1) {
@@ -104,6 +104,29 @@ module.exports = class MediaQueryPlugin {
                     if (queries) {
                         chunk.query = queries[0];
                     }
+
+
+
+
+                    // generate hash and use for [hash] within basename
+                    const hash = interpolateName({}, `[hash:${compiler.options.output.hashDigestLength}]`, { content: css });
+
+                    // compute basename according to filename option
+                    // while considering hash
+                    const filename = typeof this.options.filename == 'function'
+                        ? this.options.filename({ chunk })
+                        : this.options.filename;
+
+                    const basename = filename
+                        .replace('[name]', mediaKey)
+                        .replace(/\[(content|chunk)?hash\]/, hash)
+                        .replace(/\.[^.]+$/, '');
+
+
+
+
+
+
 
                     // find existing js & css files of this chunk
                     let existingFiles = { js: [], css: [] };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -74,16 +74,6 @@ module.exports = class MediaQueryPlugin {
                     const css = store.getMedia(mediaKey);
                     const queries = store.getQueries(mediaKey);
 
-                    // // generate hash and use for [hash] within basename
-                    // const hash = interpolateName({}, `[hash:${compiler.options.output.hashDigestLength}]`, { content: css });
-
-                    // // compute basename according to filename option
-                    // // while considering hash
-                    // const basename = this.options.filename
-                    //                     .replace('[name]', mediaKey)
-                    //                     .replace(/\[(content|chunk)?hash\]/, hash)
-                    //                     .replace(/\.[^.]+$/, '');
-
                     // if there's no chunk for the extracted media, create one
                     if (chunkIds.indexOf(mediaKey) === -1) {
                         const mediaChunk = new Chunk(mediaKey);
@@ -105,9 +95,6 @@ module.exports = class MediaQueryPlugin {
                         chunk.query = queries[0];
                     }
 
-
-
-
                     // generate hash and use for [hash] within basename
                     const hash = interpolateName({}, `[hash:${compiler.options.output.hashDigestLength}]`, { content: css });
 
@@ -121,12 +108,6 @@ module.exports = class MediaQueryPlugin {
                         .replace('[name]', mediaKey)
                         .replace(/\[(content|chunk)?hash\]/, hash)
                         .replace(/\.[^.]+$/, '');
-
-
-
-
-
-
 
                     // find existing js & css files of this chunk
                     let existingFiles = { js: [], css: [] };

--- a/src/postcss.js
+++ b/src/postcss.js
@@ -13,7 +13,7 @@ module.exports = postcss.plugin('MediaQueryPostCSS', options => {
 
         const css = postcss.root().append(atRule).toString();
         const query = atRule.params;
-        
+
         store.addMedia(name, css, options.path, query);
     }
 
@@ -53,9 +53,9 @@ module.exports = postcss.plugin('MediaQueryPostCSS', options => {
             const queryname = getQueryName(atRule.params);
 
             if (queryname) {
-                const groupName = getGroupName(options.basename);
+                const groupName = (-1 !== ['', 'main'].indexOf(options.entrypoint)) ? getGroupName(options.basename) : getGroupName(options.entrypoint);
                 const name = groupName ? `${groupName}-${queryname}` : `${options.basename}-${queryname}`;
-                
+
                 addToStore(name, atRule);
                 atRule.remove();
             }


### PR DESCRIPTION
1. With the codes inspired from https://github.com/Vyprichenko/media-query-plugin, the (output) filename can accept be set as function type (with is useful in using css-minimizer-webpack-plugin.
2. Since Webpack accepts multi-entries, it's a strong need to use the entry name rather than the file names of input. However, there is no formal Loader API to get the entry name by native, so I use the loop to identify the entry name it should be. So if there are multiple entries set in the webpack.config, then the plugin conditions (includes and groups) would check the responding entry names as possible. The fallback would be checking the original filename of input.